### PR TITLE
Version 3 seems to be for PHP but should be for SDK

### DIFF
--- a/doc_source/guide_commands.rst
+++ b/doc_source/guide_commands.rst
@@ -9,12 +9,12 @@
    limitations under the License.
 
 ##########################################
-Command Objects in the |sdk-php| Version 3
+Command Objects in the |sdk-php| (Version 3)
 ##########################################
 
 .. meta::
-   :description:  Fine-tune how the underlying HTTP handler executes the request to AWS services with the AWS SDK for PHP version 3. 
-   :keywords: AWS SDK for PHP version 3, php handler, use php for aws
+   :description:  Fine-tune how the underlying HTTP handler executes the request to AWS services with the AWS SDK for PHP - version 3. 
+   :keywords: AWS SDK for PHP - version 3, php handler, use php for aws
 
 
 The |sdk-php| uses the `command pattern <http://en.wikipedia.org/wiki/Command_pattern>`_


### PR DESCRIPTION
Version 3 seems to be for PHP but should be for SDK.  Just put the version in braces to differentiate version information separately. Was shocking to see on Google that AWS documentation is there for PHP version 3 ranking on 3rd position on Google search.

*Issue #, if available:*
PHP Version 3, this is how sentence was ending and was ranking on google which I think is not correct.

*Description of changes:*
I am not sure about more how correctly it should be written but for making it more clear, added version 3 whole in braces so it impacts for AWS SDK for PHP instead AWS SDK for PHP version 3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
