### PR TITLE
document http expect passthrough for handler

### DIFF
--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -633,9 +633,14 @@ expect
 This option is passed through to the underlying HTTP handler.  By default,
 Expect: 100-Continue header is set when the body of the request exceeds 1 MB.
 ``true`` or ``false`` enables or disables the header on all requests.  If an
-integer is used, only requests with bodies that exceed this setting wil use
+integer is used, only requests with bodies that exceed this setting will use
 the header.  When used as an integer, if the body size is unknown the Expect
 header will be sent.
+
+.. warning::
+
+Disabling the Expect header can prevent the service from returning authentication
+or other errors. This option should be configured with caution.
 
 .. _http_sink:
 

--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -625,6 +625,18 @@ You can use the ``HTTP_PROXY`` environment variable to configure an "http"
 protocol-specific proxy, and the ``HTTPS_PROXY`` environment variable to
 configure an "https" specific proxy.
 
+.. _http_expect:
+
+expect
+------
+
+This option is passed through to the underlying HTTP handler.  By default,
+Expect: 100-Continue header is set when the body of the request exceeds 1 MB.
+``true`` or ``false`` enables or disables the header on all requests.  If an
+integer is used, only requests with bodies that exceed this setting wil use
+the header.  When used as an integer, if the body size is unknown the Expect
+header will be sent.
+
 .. _http_sink:
 
 sink


### PR DESCRIPTION
https://github.com/aws/aws-sdk-php/issues/1733

documents http Expect, passing option through to underlying handler


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
