### PR TITLE
fix http expect config documentation

### DIFF
--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -537,6 +537,25 @@ delay
 The number of milliseconds to delay before sending the request. This is often
 used for delaying before retrying a request.
 
+.. _http_expect:
+
+expect
+------
+
+:Type: ``bool|string``
+
+This option is passed through to the underlying HTTP handler.  By default,
+Expect: 100-Continue header is set when the body of the request exceeds 1 MB.
+``true`` or ``false`` enables or disables the header on all requests.  If an
+integer is used, only requests with bodies that exceed this setting will use
+the header.  When used as an integer, if the body size is unknown the Expect
+header will be sent.
+
+.. warning::
+
+    Disabling the Expect header can prevent the service from returning authentication
+    or other errors. This option should be configured with caution.
+
 .. _http_progress:
 
 progress
@@ -624,23 +643,6 @@ You can connect to an AWS service through a proxy by using the ``proxy`` option.
 You can use the ``HTTP_PROXY`` environment variable to configure an "http"
 protocol-specific proxy, and the ``HTTPS_PROXY`` environment variable to
 configure an "https" specific proxy.
-
-.. _http_expect:
-
-expect
-------
-
-This option is passed through to the underlying HTTP handler.  By default,
-Expect: 100-Continue header is set when the body of the request exceeds 1 MB.
-``true`` or ``false`` enables or disables the header on all requests.  If an
-integer is used, only requests with bodies that exceed this setting will use
-the header.  When used as an integer, if the body size is unknown the Expect
-header will be sent.
-
-.. warning::
-
-Disabling the Expect header can prevent the service from returning authentication
-or other errors. This option should be configured with caution.
 
 .. _http_sink:
 


### PR DESCRIPTION
Adds missing type for HTTP Expect configuration option.
Re-orders HTTP configuration options.
Fixes indentation on warning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
