### PR TITLE
Add http_handler config section for setting TLS version

### DIFF
--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -820,9 +820,39 @@ The SDK automatically converts the given ``http_handler`` into a normal
 ``handler`` option by wrapping the provided ``http_handler`` with a
 ``Aws\WrappedHttpHandler`` object.
 
+By default, the SDK uses Guzzle as its HTTP handler. You can supply a different
+HTTP handler here, or provide a Guzzle client with your own custom defined options.
+
+**Setting TLS version**
+
+One use case is to set the TLS version used by Guzzle with Curl, assuming Curl is
+installed in your environment. Note the Curl
+`version constraints <https://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html>`_
+for what version of TLS is supported. Example setting TLS 1.2 with Guzzle 6:
+
+.. code-block:: php
+
+    use Aws\DynamoDb\DynamoDbClient;
+    use Aws\Handler\GuzzleV6\GuzzleHandler;
+    use GuzzleHttp\Client;
+
+    $handler = new GuzzleHandler(
+        new Client([
+            'curl' => [
+                CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1_2
+            ]
+        ])
+    );
+
+    $client = new DynamoDbClient([
+        'region'  => 'us-west-2',
+        'version' => 'latest',
+        'http_handler' => $handler
+    ]);
+
 .. note::
 
-    This option supersedes any provided ``handler`` option.
+    The ``http_handler`` option supersedes any provided ``handler`` option.
 
 profile
 =======

--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -825,8 +825,8 @@ HTTP handler here, or provide a Guzzle client with your own custom defined optio
 
 **Setting TLS version**
 
-One use case is to set the TLS version used by Guzzle with Curl, assuming Curl is
-installed in your environment. Note the Curl
+One use case is to set the minimum TLS version used by Guzzle with Curl,
+assuming Curl is installed in your environment. Note the Curl
 `version constraints <https://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html>`_
 for what version of TLS is supported. Example setting TLS 1.2 with Guzzle 6:
 

--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -834,7 +834,7 @@ this version, it will produce an error instead of using a lower TLS version.
 
 You can determine the TLS version being used for a given client operation by
 setting the ``debug`` client option to true and examining the SSL connection
-output.
+output. That line may look something like: ``SSL connection using TLSv1.2``
 
 Example setting TLS 1.2 with Guzzle 6:
 

--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -825,10 +825,18 @@ HTTP handler here, or provide a Guzzle client with your own custom defined optio
 
 **Setting TLS version**
 
-One use case is to set the minimum TLS version used by Guzzle with Curl,
-assuming Curl is installed in your environment. Note the Curl
+One use case is to set the TLS version used by Guzzle with Curl, assuming Curl
+is installed in your environment. Note the Curl
 `version constraints <https://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html>`_
-for what version of TLS is supported. Example setting TLS 1.2 with Guzzle 6:
+for what version of TLS is supported - by default, the highest version is used.
+If the TLS version is explicitly set, and the remote server does not support
+this version, it will produce an error instead of using a lower TLS version.
+
+You can determine the TLS version being used for a given client operation by
+setting the ``debug`` client option to true and examining the SSL connection
+output.
+
+Example setting TLS 1.2 with Guzzle 6:
 
 .. code-block:: php
 


### PR DESCRIPTION
*Description of changes:*
* Adds an example for setting TLS version in the http_handler section of the client configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
