### PR TITLE
Fix AssumeRole provider example

### DIFF
--- a/doc_source/guide_credentials_provider.rst
+++ b/doc_source/guide_credentials_provider.rst
@@ -79,6 +79,8 @@ you need to provide ``'client'`` information with an ``StsClient`` object and
 .. code-block:: php
 
     use Aws\Credentials\CredentialProvider;
+    use Aws\Credentials\InstanceProfileProvider;
+    use Aws\Credentials\AssumeRoleCredentialProvider;
     use Aws\S3\S3Client;
     use Aws\Sts\StsClient;
 


### PR DESCRIPTION
*Description of changes:*
Current code sample for the AssumeRoleCredentialProvider is using the `InstanceProfileProvider` and `AssumeRoleCredentialProvider` classes without including the corresponding namespaces, attempting to run the code as-is results in a 'Class not found' error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
