### PR TITLE
Getting started/extensions

### DIFF
--- a/doc_source/getting-started_installation.rst
+++ b/doc_source/getting-started_installation.rst
@@ -22,7 +22,11 @@ You can install the |sdk-php| Version 3:
 * As a prepackaged phar of the SDK
 * As a ZIP file of the SDK
 
-Before you install |sdk-php| Version 3 ensure your environment is using PHP version 5.5 or later. Learn more about :doc:`environment requirements and recommendations <getting-started_requirements>`
+Before you install |sdk-php| Version 3 ensure your environment is using PHP version 5.5 or later. Learn more about :doc:`environment requirements and recommendations <getting-started_requirements>`.
+
+.. note::
+
+    Installing the SDK via the .phar and .zip methods requires the `Multibyte String PHP extension <https://www.php.net/manual/en/book.mbstring.php>`_ to be installed and enabled separately.
 
 Install |sdk-php| as a dependency via Composer
 ==============================================

--- a/doc_source/getting-started_requirements.rst
+++ b/doc_source/getting-started_requirements.rst
@@ -21,7 +21,7 @@ For best results with |sdk-php|, ensure your environment supports the following 
 Requirements
 ============
 
-To use the |sdk-php|, you must be using PHP version 5.5.0 or later. If you need to sign private |CWlong| URLs, you
+To use the |sdk-php|, you must be using PHP version 5.5.0 or later with the `SimpleXML PHP extension <https://www.php.net/manual/en/book.simplexml.php>`_ enabled. If you need to sign private |CWlong| URLs, you
 also need the `OpenSSL PHP extension <http://php.net/manual/en/book.openssl.php>`_.
 
 Recommendations


### PR DESCRIPTION
*Description of changes:*
The SimpleXML extension is no longer enabled by default as of PHP7, and there is no mention that mbstring is required when using the .phar and .zip files to install the SDK. Noting both of these requirements should help alleviate confusion from customers that may encounter errors due to these extensions missing from their PHP install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
