### PR TITLE
Add missing comma to dynamodbclient example

### DIFF
--- a/doc_source/guide_configuration.rst
+++ b/doc_source/guide_configuration.rst
@@ -309,7 +309,7 @@ Here's an example of connecting to |DDBlong| Local:
 
     $client = new Aws\DynamoDb\DynamoDbClient([
         'version'  => '2012-08-10',
-        'region'   => 'us-east-1'
+        'region'   => 'us-east-1',
         'endpoint' => 'http://localhost:8000'
     ]);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There's a missing comma in the array example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
