### PR TITLE
Fix typo in navigation

### DIFF
--- a/doc_source/examples_index.md
+++ b/doc_source/examples_index.md
@@ -10,7 +10,7 @@
 + [AWS Identity and Access Management Examples](iam-examples.md)
 + [AWS Key Management Service](kms-examples.md)
 + [Amazon Kinesis Examples](kinesis-examples.md)
-+ [AWS Elemental MediaConvertt](emc-examples.md)
++ [AWS Elemental MediaConvert](emc-examples.md)
 + [Amazon S3 Examples](s3-examples.md)
 + [AWS Secrets Manager](secretsmanager-examples-manage-secret.md)
 + [Amazon SES Examples](ses-examples.md)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I was looking through the docs for the PHP SDK and noticed one of the sections in the navigation seemed to have a typo in it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
