### PR TITLE
change source_profile to use project2 instead of default

### DIFF
--- a/doc_source/guide_credentials_profiles.md
+++ b/doc_source/guide_credentials_profiles.md
@@ -72,7 +72,7 @@ Profile in `~/.aws/config`:
 ```
 [profile project1]
 role_arn = arn:aws:iam::123456789012:role/testing
-source_profile = default
+source_profile = project2
 role_session_name = OPTIONAL_SESSION_NAME
 ```
 


### PR DESCRIPTION

*Issue #, if available:*

No Issue.

*Description of changes:*

The descriptions says that the source is project2, so I have updated the sample code to reflect that.

the text says:

> Using the above files, `[project1]` will be assumed using `[project2]` as the source credentials\.

However the example shows `default` as the source profile


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
