### PR TITLE
add note about new multi-region client method

### DIFF
--- a/doc_source/guide_handlers-and-middleware.md
+++ b/doc_source/guide_handlers-and-middleware.md
@@ -38,7 +38,8 @@ You can also change the handler of a client after it is constructed using the `s
 $s3->getHandlerList()->setHandler($myHandler);
 ```
 
-**Note:** To change the handler of a multi-region client after it is constructed, use the `useCustomHandler` method of an `Aws\MultiRegionClient`.
+**Note** 
+To change the handler of a multi-region client after it is constructed, use the `useCustomHandler` method of an `Aws\MultiRegionClient`.
 
 ```
 $multiRegionClient->useCustomHandler($myHandler);

--- a/doc_source/guide_handlers-and-middleware.md
+++ b/doc_source/guide_handlers-and-middleware.md
@@ -38,6 +38,12 @@ You can also change the handler of a client after it is constructed using the `s
 $s3->getHandlerList()->setHandler($myHandler);
 ```
 
+**Note:** To change the handler of a multi-region client after it is constructed, use the `useCustomHandler` method of an `Aws\MultiRegionClient`.
+
+```
+$multiRegionClient->useCustomHandler($myHandler);
+```
+
 ### Mock Handler<a name="mock-handler"></a>
 
 We recommend using the `MockHandler` when writing tests that use the SDK\. You can use the `Aws\MockHandler` to return mocked results or throw mock exceptions\. You enqueue results or exceptions, and the MockHandler dequeues them in FIFO order\.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-php/issues/2233, PR: https://github.com/aws/aws-sdk-php/pull/2426

*Description of changes:*
Added a new method for adding customer handlers to multi-regionclients which needs to be mentioned in the user guide. Details in the linked issue/PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
