### PR TITLE
Add note regarding http debug

### DIFF
--- a/doc_source/guide_configuration.md
+++ b/doc_source/guide_configuration.md
@@ -188,7 +188,7 @@ $s3->listBuckets();
 ```
 
 **Note**  
-The debug output is extremely useful when diagnosing issues in the AWS SDK for PHP\. Please provide the debug output for an isolated failure case when opening issues on the SDK\.
+The debug output is extremely useful when diagnosing issues in the AWS SDK for PHP\. Please provide the debug output for an isolated failure case when opening issues on the SDK\. Also note that this option will also output the same information produced by the `http` debug option. Using both options simultaneously may result in errors.
 
 ## stats<a name="config-stats"></a>
 

--- a/doc_source/guide_configuration.md
+++ b/doc_source/guide_configuration.md
@@ -188,7 +188,7 @@ $s3->listBuckets();
 ```
 
 **Note**  
-The debug output is extremely useful when diagnosing issues in the AWS SDK for PHP\. Please provide the debug output for an isolated failure case when opening issues on the SDK\. Also note that this option will also output the same information produced by the `http` debug option. Using both options simultaneously may result in errors.
+The debug output is extremely useful when diagnosing issues in the AWS SDK for PHP\. This option will also output the underlying HTTP handler information produced by the `http` debug option. Please provide the debug output for an isolated failure case when opening issues on the SDK\.
 
 ## stats<a name="config-stats"></a>
 

--- a/doc_source/guide_configuration.md
+++ b/doc_source/guide_configuration.md
@@ -188,7 +188,7 @@ $s3->listBuckets();
 ```
 
 **Note**  
-The debug output is extremely useful when diagnosing issues in the AWS SDK for PHP\. This option will also output the underlying HTTP handler information produced by the `http` debug option. Please provide the debug output for an isolated failure case when opening issues on the SDK\.
+This option will also output the underlying HTTP handler information produced by the `http` debug option. The debug output is extremely useful when diagnosing issues in the AWS SDK for PHP\. Please provide the debug output for an isolated failure case when opening issues on the SDK\.
 
 ## stats<a name="config-stats"></a>
 


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/aws/aws-sdk-php/issues/2412

*Description of changes:*
Added note to specify that global debug option is extension of `http` debug option.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
